### PR TITLE
Fetch classlist to add Lecturer and User to DocumentCategory

### DIFF
--- a/apps/front/management/commands/fetch_classlist.py
+++ b/apps/front/management/commands/fetch_classlist.py
@@ -9,12 +9,14 @@ from optparse import make_option
 from django.core.management.base import BaseCommand
 
 from apps.front.management.commands.fetch_photos import UnterrichtWebsite
+from apps.front import models as front_models
 from apps.documents import models as document_models
 from apps.lecturers import models as lecturer_models
 
 
 class Command(BaseCommand):
-    help = 'Add all lecturers from classlist to modules.'
+    help = """Add all lecturers from classlist to modules and all students to
+    the modules."""
     option_list = BaseCommand.option_list + (
         make_option('--user', dest='username', help='HSR username'),
         make_option('--pass', dest='password', help='HSR password'),
@@ -24,12 +26,12 @@ class Command(BaseCommand):
         for row in table.find_all('tr')[2:]:
             try:
                 yield {
-                    'pld': int(row.find_all('div', {'class': 'a199'})[0].text),
-                    'last_name': row.find_all('a', {'class': 'a201'})[0].text,
-                    'first_name': row.find_all('div', {'class': 'a207'})[0].text,
-                    'email': row.find_all('a', {'class': 'a209'})[0].text,
-                    'abt': row.find_all('div', {'class': 'a215'})[0].text,
-                    'wl_pos': int(row.find_all('div', {'class': 'a231'})[0].text)
+                    'pld': int(row.find_all('div', {'class': 'a199'})[0].text.strip()),
+                    'last_name': row.find_all('a', {'class': 'a201'})[0].text.strip(),
+                    'first_name': row.find_all('div', {'class': 'a207'})[0].text.strip(),
+                    'email': row.find_all('a', {'class': 'a209'})[0].text.strip(),
+                    'abt': row.find_all('div', {'class': 'a215'})[0].text.strip(),
+                    'wl_pos': int(row.find_all('div', {'class': 'a231'})[0].text.strip())
                 }
             except:
                 self.stderr.write("Could not parse student: " + sys.exc_info()[0])
@@ -55,11 +57,11 @@ class Command(BaseCommand):
                 abbr = match.groups(2)
                 name = match.groups(1)
 
-                if not abbr in lecturers:
+                if abbr not in lecturers:
                     lecturers[abbr] = name
             except:
-                self.stderr.write("Could not parse lecturers in {0};{1};{2}: {3}"\
-                                  .format(module_id, course_id, unit_id,sys.exc_info()[0]))
+                self.stderr.write("Could not parse lecturers in {0};{1};{2}: {3}"
+                                  .format(module_id, course_id, unit_id, sys.exc_info()[0]))
 
         return set(lecturers)
 
@@ -73,51 +75,57 @@ class Command(BaseCommand):
         :returns dictionary with all the important properties of a module
         """
         try:
-            course_list = hsr.get_class_list(module_id=module_id,course_id=module_id+1)
+            course_list = hsr.get_class_list(module_id=module_id, course_id=module_id + 1)
             abbr = course_list.content.find_all('a', {'class': 'a40'})[0].text
             student_count = int(course_list.content.find_all('div', {'class': 'a125'})[0].text)
             table = course_list.content.find_all('table', {'class': 'a292'})[0]
             students = self.parse_student_table(table)
             lecturers = self.parse_lecturers_of_course_units(hsr,
                                                              module_id,
-                                                             module_id+1,
+                                                             module_id + 1,
                                                              course_list.course_units)
             return {
-                'abbr':abbr,
+                'abbr': abbr,
                 'student_count': student_count,
                 'students': students,
-                'lecturers':lecturers
+                'lecturers': lecturers
             }
         except:
-            self.stderr.write("Could not parse module {0}: {1}"\
+            self.stderr.write("Could not parse module {0}: {1}"
                               .format(module_id, sys.exc_info()[0]))
 
-    def add_lecturers_to_document_category(self, module):
+    def get_document_category(self, abbr):
+        try:
+            return document_models.DocumentCategory.objects.get(name=abbr)
+        except document_models.DocumentCategory.DoesNotExist:
+            self.stderr.write("Could not find DocumentCategory {0}".format(abbr))
+
+    def add_lecturers_to_document_category(self, lecturers, category):
         """Try to find all the lecturers in the database and add them to the
         category if the category exists as well.
         returns: Tuple of added lecturers and failed lecturers or none if category
         does not exist
         """
-        added_lecturer_count = 0
-        failed_lecturer_count = 0
+        added_lecturers = []
+        failed_lecturers = []
 
-        try:
-            category = document_models.DocumentCategory.objects.get(name=module['abbr'])
+        for name, abbr in lecturers:
+            try:
+                lecturer = lecturer_models.Lecturer.objects.get(abbreviation=abbr)
+                category.lecturers.add(lecturer)
+                added_lecturers.append(name)
+            except lecturer_models.Lecturer.DoesNotExist:
+                failed_lecturers.append(name)
+                self.stderr.write("Could not find Lecturer {0} ({1})".format(name, abbr))
 
-            for name, abbr in module['lecturers']:
-                try:
-                    lecturer = lecturer_models.Lecturer.objects.get(abbreviation=abbr)
-                    category.lecturers.add(lecturer)
-                    added_lecturer_count += 1
-                except lecturer_models.Lecturer.DoesNotExist:
-                    failed_lecturer_count += 1
-                    self.stderr.write("Could not find Lecturer {0} ({1})".format(name, abbr))
+        category.save()
+        return (added_lecturers, failed_lecturers)
 
-            category.save()
-            return (added_lecturer_count, failed_lecturer_count)
-        except document_models.DocumentCategory.DoesNotExist:
-            self.stderr.write("Could not find DocumentCategory {0}".format(module['abbr']))
-
+    def get_module_ids(self, hsr):
+        """Extract module ids from the options of the initial list"""
+        initial_list = hsr.get_class_list()
+        options = initial_list.modules.find_all('option')[1:]
+        return [int(option['value']) for option in options]
 
     def handle(self, **options):
         """Parse all modules from the select list from
@@ -129,41 +137,49 @@ class Command(BaseCommand):
         if not ('password' in options and options['password']):
             options['password'] = getpass.getpass('HSR Password: ').strip()
 
-
         # Initialize counters
         start = time.time()
-        added_lecturer_count = 0
-        failed_lecturer_count = 0
-        updated_category_count = 0
-        failed_category_count = 0
+        added_lecturers = []
+        failed_lecturers = []
+        updated_categories = []
+        failed_categories = []
 
         # Initialize HsrWebsite object to fetch person IDs
         hsr = UnterrichtWebsite()
         hsr.login(options['username'], options['password'])
 
-        # Load the initial class list to extract modules
-        initial_list = hsr.get_class_list()
-        options = initial_list.modules.find_all('option')[1:]
-        module_ids = [int(option['value']) for option in options]
+        for module_id in self.get_module_ids(hsr):
 
-        for module_id in module_ids:
             module = self.parse_module(hsr, module_id)
-            results = self.add_lecturers_to_document_category(module)
+            category = self.get_document_category(module['abbr'])
+            lecturers = module['lecturers']
+            students = module['students']
 
-            if results:
-                added_lecturer_count += results[0]
-                failed_lecturer_count += results[1]
-                updated_category_count += 1
-                self.stdout.write('Added {0} lecturer to module {1} and {2} failed'\
-                                  .format(results[0], module['abbr'], results[1]))
+            if category:
+                lecturer_results = self.add_lecturers_to_document_category(lecturers, category)
+                added_lecturers.extend(lecturer_results[0])
+                failed_lecturers.extend(lecturer_results[1])
+                self.stdout.write('Added {0} lecturer to module {1} and {2} failed'
+                                  .format(len(lecturer_results[0]),
+                                          module['abbr'],
+                                          len(lecturer_results[1])))
+
+                updated_categories.append(module['abbr'])
             else:
-                failed_category_count += 1
+                failed_categories.append(module['abbr'])
+
+        # Remove duplicates
+        added_lecturers = set(added_lecturers)
+        failed_lecturers = set(failed_lecturers)
+
+        self.stdout.write('Updated {0} modules: {1}'
+                          .format(len(updated_categories), ",".join(updated_categories)))
+        self.stdout.write('Failed {0} modules: {1}'
+                          .format(len(failed_categories), ",".join(failed_categories)))
+        self.stdout.write('Added {0} lecturers: {1}'
+                          .format(len(added_lecturers), ",".join(added_lecturers)))
+        self.stdout.write('Failed {0} lecturers: {1}'
+                          .format(len(failed_lecturers), ",".join(failed_lecturers)))
 
         end = time.time()
         self.stdout.write('Used {0} to parse all the modules and lecturers.'.format(end))
-
-        self.stdout.write('Updated {0} modules.'.format(updated_category_count))
-        self.stdout.write('Failed {0} modules.'.format(failed_category_count))
-        self.stdout.write('Added {0} lecturers.'.format(added_lecturer_count))
-        self.stdout.write('Failed {0} lecturers.'.format(failed_lecturer_count))
-

--- a/apps/front/management/commands/fetch_photos.py
+++ b/apps/front/management/commands/fetch_photos.py
@@ -25,7 +25,8 @@ class UnterrichtWebsite(object):
         'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.1 (KHTML, like Gecko) ' +
                       'Chrome/21.0.1180.89 Safari/537.1',
     }
-    ClassList = namedtuple('ClassList', ['organizations', 'modules', 'courses', 'course_units', 'content'])
+    ClassList = namedtuple('ClassList',
+                           ['organizations', 'modules', 'courses', 'course_units', 'content'])
 
     def __init__(self):
         """Initialize requests session."""
@@ -80,10 +81,11 @@ class UnterrichtWebsite(object):
 
     def get_class_list(self, organization_id=-1, module_id=-1, course_id=-1, course_unit_id=-1):
         assert self.logged_in(), 'Not logged in. Please call login().'
-        url = "https://unterricht.hsr.ch/CurrentSem/Reporting/Registrations/Module?organizationUnitId={0}&courseUnitId={1};{2};{3}".format(organization_id, module_id, course_id, course_unit_id)
+        url = "https://unterricht.hsr.ch/CurrentSem/Reporting/Registrations/Module?\
+        organizationUnitId={0}&courseUnitId={1};{2};{3}"\
+        .format(organization_id, module_id, course_id, course_unit_id)
         r = self.s.get(url)
         soup = BeautifulSoup(r.content)
-
 
         organizations = soup.find(id='Parameter_OrganizationUnitId')
         modules = soup.find(id='Parameter_ModuleId')


### PR DESCRIPTION
Sadly I could not get all the lecturers that are associated with the lectures #133  from studien.hsr.ch.
This approach is a bit different, it parses the class lists of the current semester and aggregates all the lecturers from the different exercises and lectures of a module.

When parsing the class list we can also find out, which of our users are registered in which module. This provides data for future features like showing only the modules that the user is registered to in the current semester. That's why I added a Many-2-Many relationship between the users and modules.

We could do even more things with the data of the class list, like pulling out the first_name and last_name or the student photo (but I'm not sure if I would want that as a student :grin: ).

Interesting fact I found out while I ran this:
Of the current semester 538 users are not registered (and I even know which ones :grin:) to the studentenportal while 725 users are.

Edit: Uups just saw all my PEP violations, will fix that first
