### PR TITLE
Upgrade django-mathfilters to 1.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ django-registration-redux==1.9
 django-sendfile==0.3.11
 django-model-utils==1.3.1
 django_compressor==2.4
-django-mathfilters==0.1.3
+django-mathfilters>=1.0,<1.1
 easy-thumbnails==2.5
 pyScss==1.3.5
 


### PR DESCRIPTION
Ich habe gerade 1.0.0 von django-mathfilters released und wollte es im Studentenportal testen :slightly_smiling_face: Scheint alles noch zu funktionieren.