### PR TITLE
docker-compose: Ensure that containers are restarted

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -26,6 +26,8 @@ services:
         aliases:
           - webserver
 
+    restart: unless-stopped
+
     depends_on:
       - studentenportal
 
@@ -45,6 +47,8 @@ services:
           aliases:
             - database
             - postgres
+
+    restart: unless-stopped
 
 # studentenportal - Application server with python
   studentenportal:


### PR DESCRIPTION
With the previous setup, when restarting the docker daemon or the system, both the nginx and the postgres container wouldn't start automatically.