### PR TITLE
GitHub CI: Only build Docker image after tests succeed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"
       DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
     if: github.ref == 'refs/heads/master'
+    needs: test
     steps:
       - uses: actions/checkout@v2
       - name: Fetch repository tags (for git describe to work)


### PR DESCRIPTION
This is not strictly necessary because the publish step only happens on
the main branch (which is only modified by successfully tested PRs).
However, it's still better to only publish when tests pass.