### PR TITLE
Actually fail CI when tests fail

### DIFF
--- a/deploy/dev/test.sh
+++ b/deploy/dev/test.sh
@@ -23,7 +23,7 @@ PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d 
 coverage run --source apps -m pytest "$@"
 pytest_exit=$?
 
-echo
+echo ""
 (( pytest_exit == 0 )) && coverage report
 if [[ "$generate_xml" == 1 ]]; then echo "Generating XML coverage file"; coverage xml; fi
 

--- a/deploy/dev/test.sh
+++ b/deploy/dev/test.sh
@@ -20,5 +20,11 @@ done
 export PYTHONPATH=$(pwd)
 
 PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d template1 -c 'CREATE EXTENSION IF NOT EXISTS citext;'
-coverage run --source apps -m pytest "$@" && echo && coverage report
+coverage run --source apps -m pytest "$@"
+pytest_exit=$?
+
+echo
+(( pytest_exit == 0 )) && coverage report
 if [[ "$generate_xml" == 1 ]]; then echo "Generating XML coverage file"; coverage xml; fi
+
+exit "$pytest_exit"


### PR DESCRIPTION
test.sh shadowed pytest's exit status, so the CI happily passes even with test failures...