### PR TITLE
Set permissions for uploaded files

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -175,6 +175,7 @@ ROOT_URLCONF = 'config.urls'
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 
 MAX_UPLOAD_SIZE = 1024 * 1024 * 20 # 20MB
+FILE_UPLOAD_PERMISSIONS = 0o644  # Default with Django 3.0
 
 AUTH_USER_MODEL = 'front.User'
 


### PR DESCRIPTION
With Django 2.2, FILE_UPLOAD_PERMISSIONS is None by default:
https://docs.djangoproject.com/en/2.2/ref/settings/#file-upload-permissions

This means the behavior is rather inconsistent:

    If this isn’t given or is None, you’ll get operating-system
    dependent behavior. On most platforms, temporary files will have a
    mode of 0o600, and files saved from memory will be saved using the
    system’s standard umask.

Together with how Django handles uploaded files:

    Together MemoryFileUploadHandler and TemporaryFileUploadHandler
    provide Django’s default file upload behavior of reading small files
    into memory and large ones onto disk.

    https://docs.djangoproject.com/en/3.1/topics/http/file-uploads/#upload-handlers

This means that larger files (uploaded via a temporary file) result in a
file with 600 permissions on disk, which can't be read by nginx.

To fix this inconsistency, Django 3.0 changed the default to 0o644:
https://docs.djangoproject.com/en/3.1/topics/http/file-uploads/#upload-handlers

We use Django 2.2 at the moment, but we should do the same so that we
always get correct permissions for uploaded files, no matter their size.

Fixes studentenportal/deploy2020#24